### PR TITLE
Checkout popup scrolls correctly, mirrors order pg

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,8 @@
 
             <span class="ingredientsPopupMessage"></span>
 
-            <div class="popupButtonWrapper">
+            <!-- Needs a separate name or else cannot grab height correctly, but pulls from CSS in popupButtonWrapper class -->
+            <div class="popupButtonWrapperCheckout popupButtonWrapper">
                 <a href="#" class="saveItemButton" data-role="button" data-theme="a" data-inline="true" data-rel="back" data-theme="c" data-type="horizontal">
                     Save
                 </a>

--- a/stylesAccordian.css
+++ b/stylesAccordian.css
@@ -374,7 +374,7 @@
     padding-top:0;
     height:100%;
     width:100%;
-    overflow:hidden;
+    overflow:scroll;
 }
 
 #addCancelWrapper {
@@ -455,12 +455,16 @@
     float:left;
     clear:both;
     padding-left:30px;
+    margin-top:0;
+    margin-bottom:0;
 }
 
 .ingredientsListCheckout { /* for checkout page's popup */
     float:left;
     clear:both;
     padding-left:30px;
+    margin-top:0;
+    margin-bottom:0;
 }
 
 .itemOptions {


### PR DESCRIPTION
Correctly disables the background from scrolling, makes ingredients list scroll-able depending on whether or not the ingredients list is too long to fit in the popup
